### PR TITLE
fix: abort streams with never ending reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Make any iterator or iterable abortable via an `AbortSignal`.
 | options.abortMessage | `String` | The message that the error will have if the iterator is aborted. Default "The operation was aborted" |
 | options.abortCode | `String`\|`Number` | The value assigned to the `code` property of the error that is thrown if the iterator is aborted. Default "ABORT_ERR" |
 | options.returnOnAbort | `Boolean` | Instead of throwing the abort error, just return from iterating over the source stream. |
+| options.onReturnError | `Function` | When a generator is aborted, we call `.return` on it - if this function errors the error value will be passed to the `.onReturnError` callback if passed. Default `null` |
 
 #### Returns
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ type Options<T> = {
   abortMessage?: string
   abortCode?: string
   returnOnAbort?: boolean
+  onReturnError?: (err: Error) => void
 }
 
 type Signals<T> = {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,11 @@ const toMultiAbortableSource = (source, signals) => {
 
         // End the iterator if it is a generator
         if (typeof source.return === 'function') {
-          await source.return()
+          source.return().catch(err => {
+            if (aborter.options.onReturnError) {
+              aborter.options.onReturnError(err)
+            }
+          })
         }
 
         if (isKnownAborter && aborter.options.returnOnAbort) {


### PR DESCRIPTION
When calling `.return` on a generator object, it means the next call to `.next` will result in `{ done: true }`.  If there's an in-flight invocation of `.next`, that needs to resolve before the `.return` will be processed.  If `.next` never resolves, `.return` will never be processed, the `AbortError` will never be thrown and everything hangs indefinitely.

The fix here is to not await on the result of `.return` and move on to throwing the `AbortError`.  If `.return` rejects we should do something with the error, so a new `onReturnError` callback is added to the options to receive the error if the caller is interested.