### PR TITLE
fix: re-enable transform duplex test

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "aegir": "^36.1.3",
     "delay": "^5.0.0",
     "it-drain": "^1.0.5",
-    "it-pipe": "^2.0.0"
+    "it-pipe": "^2.0.2"
   },
   "repository": {
     "type": "git",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -193,7 +193,7 @@ describe('abortable-iterator', () => {
       .to.eventually.be.rejected.with.property('type', 'aborted')
   })
 
-  it.skip('should abort a duplex used as a transform', async () => {
+  it('should abort a duplex used as a transform', async () => {
     const controller = new AbortController()
     const duplex: Duplex<number> = {
       source: forever(),


### PR DESCRIPTION
Fix in it-pipe lets us abort duplex streams used as transforms.

Refs: https://github.com/alanshaw/it-pipe/pull/8