### PR TITLE
feat: add `abortName` option to override thrown error name

### DIFF
--- a/src/abort-error.ts
+++ b/src/abort-error.ts
@@ -2,9 +2,10 @@ export class AbortError extends Error {
   type: string
   code: string
 
-  constructor (message?: string, code?: string) {
+  constructor (message?: string, code?: string, name?: string) {
     super(message ?? 'The operation was aborted')
     this.type = 'aborted'
     this.code = code ?? 'ABORT_ERR'
+    this.name = name ?? 'AbortError'
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export interface Options<T> {
   onAbort?(source: Source<T>): void
   abortMessage?: string
   abortCode?: string
+  abortName?: string
   returnOnAbort?: boolean
 }
 
@@ -75,14 +76,14 @@ export function abortableSource <T> (source: Source<T>, signal: AbortSignal, opt
       let result: IteratorResult<T, any>
       try {
         if (signal.aborted) {
-          const { abortMessage, abortCode } = opts
-          throw new AbortError(abortMessage, abortCode)
+          const { abortMessage, abortCode, abortName } = opts
+          throw new AbortError(abortMessage, abortCode, abortName)
         }
 
         const abort = new Promise<any>((resolve, reject) => { // eslint-disable-line no-loop-func
           nextAbortHandler = () => {
-            const { abortMessage, abortCode } = opts
-            reject(new AbortError(abortMessage, abortCode))
+            const { abortMessage, abortCode, abortName } = opts
+            reject(new AbortError(abortMessage, abortCode, abortName))
           }
         })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -240,4 +240,19 @@ describe('abortable-iterator', () => {
     })())
       .to.eventually.be.rejected.with.property('type', 'aborted')
   })
+
+  it('should override abort error properties', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    const err = await drain(abortableSource(forever(), controller.signal, {
+      abortCode: 'custom code',
+      abortMessage: 'custom message',
+      abortName: 'custom name'
+    })).catch(err => err)
+
+    expect(err).to.have.property('code', 'custom code')
+    expect(err).to.have.property('message', 'custom message')
+    expect(err).to.have.property('name', 'custom name')
+  })
 })


### PR DESCRIPTION
The `.name` property is more ideomatic than a `.code` property so allow overriding it via options.